### PR TITLE
Add Wondika to Applications

### DIFF
--- a/src/awesome.js
+++ b/src/awesome.js
@@ -80,6 +80,15 @@ export default {
             {
                 "full_name": "TablePlus/TablePlus"
             },
+            {
+                "external": true,
+                "name": "Wondika",
+                "owner": {
+                    "name": "Hau Vo"
+                },
+                "html_url": "https://wondika.com",
+                "description": "AI-generated math story adventures for kids ages 6–11 (K–5), with English and Vietnamese voice narration. iOS, Android, web."
+            },
         ]
     },
     "Angular": {


### PR DESCRIPTION
Adds Wondika (external entry) under Applications.

Wondika is an iOS/Android/Web app built by a Vietnamese team that teaches K–5 math to kids ages 6–11 through AI-generated, illustrated, multi-scene story adventures. Each play, the AI generates a unique episode around a chosen math skill and story world, weaving challenges into the narrative. Full English and Vietnamese voice narration, no ads, COPPA / GDPR-K compliant.

Site: https://wondika.com

Added as an external entry (no public GitHub repo), matching the existing pattern used for dbdiagram.io etc.